### PR TITLE
Support the quiet command line arg

### DIFF
--- a/pluto/lib/pluto/cli/main.rb
+++ b/pluto/lib/pluto/cli/main.rb
@@ -382,7 +382,11 @@ pre do |g,c,o,args|
 
   puts PlutoCli.banner
 
-  LogUtils::Logger.root.level = :debug    if opts.verbose?
+  if opts.verbose?
+    LogUtils::Logger.root.level = :debug
+  elsif opts.quiet?
+    LogUtils::Logger.root.level = :warn
+  end
 
   logger.debug "   executing command #{c.name}"
   true

--- a/pluto/lib/pluto/cli/opts.rb
+++ b/pluto/lib/pluto/cli/opts.rb
@@ -10,7 +10,8 @@ class Opts
 
 
   def merge_gli_options!( options={} )
-    @verbose = true     if options[:verbose] == true
+    @verbose = true   if options[:verbose] == true
+    @quiet = true     if options[:quiet] == true
 
     @db_path   = options[:dbpath]  if options[:dbpath].present?
 
@@ -48,6 +49,15 @@ class Opts
   def verbose?
     @verbose || false
   end
+
+  def quiet=(value)
+    @quiet = true  # note: always assumes true for now; default is false
+  end
+
+  def quiet?
+    @quiet || false
+  end
+
 
   def config_path=(value)
     @config_path = value


### PR DESCRIPTION
Feed through the 'quiet' command line arg int an 'opts' boolean,
but use it just to set the log level to 'warn'

This tackling https://github.com/feedreader/pluto/issues/4 but...

TODO: use loggers instead puts everywhere