### PR TITLE
Delete items which are removed from a feed

### DIFF
--- a/pluto-models/test/test_delete_removed.rb
+++ b/pluto-models/test/test_delete_removed.rb
@@ -1,0 +1,66 @@
+# encoding: utf-8
+
+###
+#  to run use
+#     ruby -I ./lib -I ./test test/test_delete_removed.rb
+#  or better
+#     rake test
+
+require 'helper'
+
+class TestDeleteRemoved < MiniTest::Test
+
+  def test_delete_removed
+
+    feed = Feed.create!(
+      key: 'test',
+      title: 'Feed title'
+    )
+
+    feed_data = FeedParser::Feed.new
+    feed_data.title = 'Feed data title'
+    feed_data.items = []
+
+    item_data = FeedParser::Item.new
+    item_data.guid = 'https://myblog.com/?p=1113'
+    item_data.title = 'Good post #3'
+    item_data.published = Time.now
+    feed_data.items << item_data
+
+    item_data = FeedParser::Item.new
+    item_data.guid = 'https://myblog.com/?p=1112'
+    item_data.title = 'Spam post #2'
+    item_data.published = Time.now - 10.minutes
+    feed_data.items << item_data
+
+    item_data = FeedParser::Item.new
+    item_data.guid = 'https://myblog.com/?p=1111'
+    item_data.title = 'Good post #1'
+    item_data.published = Time.now - 20.minutes
+
+    feed_data.items << item_data
+
+    feed.deep_update_from_struct!( feed_data )
+
+    assert_equal(3, Item.count)
+
+
+    feed_data.items = []
+
+    item_data = FeedParser::Item.new
+    item_data.guid = 'https://myblog.com/?p=1113'
+    item_data.title = 'Good post #2'
+    item_data.published = Time.now
+    feed_data.items << item_data
+
+    item_data = FeedParser::Item.new
+    item_data.guid = 'https://myblog.com/?p=1111'
+    item_data.title = 'Good post #1'
+    item_data.published = Time.now - 20.minutes
+    feed_data.items << item_data
+
+    feed.deep_update_from_struct!( feed_data )
+
+    assert_equal(2, Item.count)
+  end
+end # class TestDeleteRemoved


### PR DESCRIPTION
Trying to fix this spam problem on blog.openstreetmap.org: https://github.com/gravitystorm/blogs.osm.org/issues/17 I've come up with this logic which I believe will solve it.

I've added a test. I have now also tested this logic end-to-end within a full pluto set-up, and it seems to work as expected. I've only done that by hacking the gem internals. I didn't figure out how to build this into a gem properly. The multi-gem set-up with hoe is confusing to me at the moment.

Also you may prefer to make this behaviour _optional_, as a thing users can switch on for a particular feed (so a config option for the ini file entries, rather like filters). I took a look at doing this, but for similar reasons passing the option through multiple gems seemed tricky.

Having said that, I could make a case that the "delete removed" behaviour is actually desirable as reasonable default. For most blog feeds most of the time it will make no difference (find nothing was removed), but presumably if a source blogger ever wants to delete an entry they published by accident they'll run into the same problem we're seeing with deleting spam diary entries.