### PR TITLE
Handle SystemCallError in feedfetcher gracefully

### DIFF
--- a/pluto-feedfetcher/lib/pluto/feedfetcher/cond_get_with_cache.rb
+++ b/pluto-feedfetcher/lib/pluto/feedfetcher/cond_get_with_cache.rb
@@ -33,7 +33,7 @@ class FeedFetcherCondGetWithCache
 
     begin
       response = @worker.get( feed_url )
-    rescue SocketError => e
+    rescue SocketError, SystemCallError => e
       ## catch socket error for unknown domain names (e.g. pragdave.blogs.pragprog.com)
       ###  will result in SocketError -- getaddrinfo: Name or service not known
       logger.error "*** error: fetching feed '#{feed_key}' - #{e.to_s}"


### PR DESCRIPTION
Connection failures (as opposed to DNS problems) are reported as
SystemCallError rather than SocketError.  Catch both exception types
to handle them gracefully.

Fixes #19