### PR TITLE
Work around removal of "to_h" method in Rails 7.0

### DIFF
--- a/pluto-models/Rakefile
+++ b/pluto-models/Rakefile
@@ -8,7 +8,7 @@ Hoe.spec 'pluto-models' do
   self.summary = "pluto-models - planet schema 'n' models for easy (re)use"
   self.description = summary
 
-  self.urls    = ['https://github.com/feedreader/pluto']
+  self.urls    = { 'home': 'https://github.com/feedreader/pluto' }
 
   self.author  = 'Gerald Bauer'
   self.email   = 'wwwmake@googlegroups.com'

--- a/pluto-models/lib/pluto/connecter.rb
+++ b/pluto-models/lib/pluto/connecter.rb
@@ -63,11 +63,10 @@ class Connecter
       logger.debug ActiveRecord::Base.configurations.pretty_inspect
     end
 
-    # note: for now always use pluto key for config storage
-    configs = ActiveRecord::Base.configurations.to_h.reject { |db_config| db_config.env_name == 'pluto' }
-    configs['pluto'] = config
+    configurations = ActiveRecord::Base.configurations.configs_for(env_name: 'pluto')
+    configurations << config
 
-    ActiveRecord::Base.configurations = configs
+    ActiveRecord::Base.configurations = configurations
 
     if debug?
       logger.debug 'ar configurations (after):'

--- a/pluto-models/lib/pluto/models/feed.rb
+++ b/pluto-models/lib/pluto/models/feed.rb
@@ -259,7 +259,7 @@ class Feed < ActiveRecord::Base
     ##  todo/check - limit to atom feed format only - why? why not?
 
     count           = data.items.size
-    count_published = data.items.reduce( 0 ) {|count,item| count += 1 if item.published; count }
+    count_published = data.items.reduce( 0 ) {|cnt,item| cnt += 1 if item.published; cnt }
 
     if count == count_published
       uniq_count_updated  = 0

--- a/pluto-models/test/test_delete_removed.rb
+++ b/pluto-models/test/test_delete_removed.rb
@@ -5,7 +5,7 @@
 
 require 'helper'
 
-class TestDeleteRemoved < MiniTest::Test
+class TestDeleteRemoved < Minitest::Test
 
   def test_delete_removed
 

--- a/pluto-models/test/test_filter.rb
+++ b/pluto-models/test/test_filter.rb
@@ -5,7 +5,7 @@
 
 require 'helper'
 
-class TestFilter < MiniTest::Test
+class TestFilter < Minitest::Test
 
   def test_includes
 

--- a/pluto-models/test/test_helpers.rb
+++ b/pluto-models/test/test_helpers.rb
@@ -5,7 +5,7 @@
 
 require 'helper'
 
-class TestHelper < MiniTest::Test
+class TestHelper < Minitest::Test
 
   def setup
     Log.delete_all

--- a/pluto-models/test/test_regex.rb
+++ b/pluto-models/test/test_regex.rb
@@ -5,7 +5,7 @@
 
 require 'helper'
 
-class TestRegex < MiniTest::Test
+class TestRegex < Minitest::Test
 
   FIX_DATE_SLUG_RE = Pluto::Model::Feed::FIX_DATE_SLUG_RE
 

--- a/pluto-models/test/test_site.rb
+++ b/pluto-models/test/test_site.rb
@@ -5,7 +5,7 @@
 
 require 'helper'
 
-class TestSite < MiniTest::Test
+class TestSite < Minitest::Test
 
   def setup
     Log.delete_all

--- a/pluto-update/attic/subscriber.rb
+++ b/pluto-update/attic/subscriber.rb
@@ -2,6 +2,6 @@
 
   def update_subscriptions( config, opts={} )
     # !!!! -- depreciated API - remove - do NOT use anymore
-    puts "*** warn - [Pluto::Subscriber] depreciated API -- use update_subscriptions_for( site_key )"
+    puts "*** warn: [Pluto::Subscriber] depreciated API -- use update_subscriptions_for( site_key )"
     update_subscriptions_for( 'planet', config, opts )  # default to planet site_key
   end


### PR DESCRIPTION
As mentioned in #44 and #42 

We've been getting this issue in Planet OpenSUSE and it's holding the repo back from using more modern Ruby + ActiveRecord versions. Hopefully this helps bring this repo's version compatibility up to date :)

https://github.com/openSUSE/planet-o-o/actions/runs/8309794922/job/22741562517#step:5:12