### PR TITLE
add OpenSSL error to rescue list

### DIFF
--- a/pluto-feedfetcher/lib/pluto/feedfetcher/cond_get_with_cache.rb
+++ b/pluto-feedfetcher/lib/pluto/feedfetcher/cond_get_with_cache.rb
@@ -39,7 +39,8 @@ class FeedFetcherCondGetWithCache
      ## or giving up and showing a helpful error to the user.
      ## --  <https://www.exceptionalcreatures.com/bestiary/Net/OpenTimeout.html>
 
-    rescue Net::OpenTimeout,
+    rescue OpenSSL::SSL::SSLError,
+           Net::OpenTimeout,
            Net::ReadTimeout, 
            SocketError, 
            SystemCallError => e


### PR DESCRIPTION
fixes https://github.com/feedreader/pluto/issues/31

SSL errors will no longer cause builds to fail, leaving partial results.
Only the feed with broken SSL (or the other supported errors) will be skipped.